### PR TITLE
Managed AudioContext, engine queue, and UI cleanup

### DIFF
--- a/apps/sequencer/package.json
+++ b/apps/sequencer/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@web-audio/audio-engine": "workspace:*",
     "@web-audio/clock": "workspace:*",
+    "@web-audio/context": "workspace:*",
     "@web-audio/fluid": "workspace:*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/apps/sequencer/src/App.tsx
+++ b/apps/sequencer/src/App.tsx
@@ -43,33 +43,30 @@ function App() {
     return clockRef.current;
   };
 
+  const getEngine = () => {
+    if (!engineRef.current) {
+      engineRef.current = new AudioEngine(getAudio().ctx, getClock());
+    }
+    return engineRef.current;
+  };
+
   const stopClock = () => {
     if (!isRunning) return;
-    engineRef.current?.destroy();
-    engineRef.current = null;
     clockRef.current?.stop();
     setIsRunning(false);
   };
 
   const evaluate = async (input: string) => {
-    engineRef.current?.destroy();
-    engineRef.current = null;
-
     try {
       const d = new Drome();
       new Function("drome", "d", input)(d, d);
       const schema = d.getSchema();
 
-      const clock = getClock();
+      getEngine().update(schema);
 
       if (!isRunning) {
-        if (schema.instruments.length > 0) {
-          engineRef.current = new AudioEngine(getAudio().ctx, clock, schema);
-        }
-        await clock.start();
+        await getClock().start();
         setIsRunning(true);
-      } else if (schema.instruments.length > 0) {
-        engineRef.current = new AudioEngine(getAudio().ctx, clock, schema);
       }
 
       addLog("✓", "output");

--- a/apps/sequencer/src/App.tsx
+++ b/apps/sequencer/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import AudioClock from "@web-audio/clock";
+import { createAudioContext, type ManagedAudioContext } from "@web-audio/context";
 import Drome from "@web-audio/fluid";
 import AudioEngine from "@web-audio/audio-engine";
 
@@ -17,6 +18,7 @@ function App() {
   const [isRunning, setIsRunning] = useState(false);
   const [code, setCode] = useState(DEFAULT_CODE);
   const [logs, setLogs] = useState<LogEntry[]>([]);
+  const audioRef = useRef<ManagedAudioContext | null>(null);
   const clockRef = useRef<AudioClock | null>(null);
   const engineRef = useRef<AudioEngine | null>(null);
 
@@ -24,11 +26,22 @@ function App() {
     setLogs((prev) => [{ text, type }, ...prev]);
   };
 
+  const getAudio = () => {
+    if (!audioRef.current) {
+      audioRef.current = createAudioContext();
+    }
+    return audioRef.current;
+  };
+
+  const getClock = () => {
+    if (!clockRef.current) {
+      clockRef.current = new AudioClock(getAudio().ctx, 140, 4);
+    }
+    return clockRef.current;
+  };
+
   const startClock = async () => {
-    const ctx = new AudioContext();
-    const clock = new AudioClock(ctx, 140, 4);
-    clockRef.current = clock;
-    await clock.start();
+    await getClock().start();
     setIsRunning(true);
   };
 
@@ -36,7 +49,6 @@ function App() {
     engineRef.current?.destroy();
     engineRef.current = null;
     clockRef.current?.stop();
-    clockRef.current = null;
     setIsRunning(false);
   };
 
@@ -49,24 +61,16 @@ function App() {
       new Function("drome", "d", input)(d, d);
       const schema = d.getSchema();
 
-      if (!clockRef.current) {
-        // Initial start: subscribe the engine BEFORE clock.start() so it
-        // receives bar 0 when the scheduler fires it on the first tick.
-        const ctx = new AudioContext();
-        const clock = new AudioClock(ctx, 140, 4);
-        clockRef.current = clock;
+      const clock = getClock();
+
+      if (!isRunning) {
         if (schema.instruments.length > 0) {
-          engineRef.current = new AudioEngine(ctx, clock, schema);
+          engineRef.current = new AudioEngine(getAudio().ctx, clock, schema);
         }
         await clock.start();
         setIsRunning(true);
       } else if (schema.instruments.length > 0) {
-        // Mid-session: AudioEngine pre-schedules the next bar internally.
-        engineRef.current = new AudioEngine(
-          clockRef.current.ctx,
-          clockRef.current,
-          schema,
-        );
+        engineRef.current = new AudioEngine(getAudio().ctx, clock, schema);
       }
 
       addLog("✓", "output");
@@ -86,6 +90,7 @@ function App() {
     return () => {
       engineRef.current?.destroy();
       clockRef.current?.stop();
+      audioRef.current?.dispose();
     };
   }, []);
 

--- a/apps/sequencer/src/App.tsx
+++ b/apps/sequencer/src/App.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import AudioClock from "@web-audio/clock";
-import { createAudioContext, type ManagedAudioContext } from "@web-audio/context";
+import {
+  createAudioContext,
+  type ManagedAudioContext,
+} from "@web-audio/context";
 import Drome from "@web-audio/fluid";
 import AudioEngine from "@web-audio/audio-engine";
 
@@ -40,12 +43,8 @@ function App() {
     return clockRef.current;
   };
 
-  const startClock = async () => {
-    await getClock().start();
-    setIsRunning(true);
-  };
-
   const stopClock = () => {
+    if (!isRunning) return;
     engineRef.current?.destroy();
     engineRef.current = null;
     clockRef.current?.stop();
@@ -100,10 +99,10 @@ function App() {
     >
       <div style={{ display: "flex", gap: "8px", marginBottom: "12px" }}>
         <button
-          onClick={isRunning ? stopClock : startClock}
+          onClick={() => evaluate(code)}
           style={{
             padding: "6px 16px",
-            backgroundColor: isRunning ? "#ff4757" : "#2ed573",
+            backgroundColor: "#1e90ff",
             color: "white",
             border: "none",
             borderRadius: "4px",
@@ -111,8 +110,28 @@ function App() {
             fontFamily: "monospace",
           }}
         >
-          {isRunning ? "stop" : "start"}
+          run
         </button>
+        <button
+          onClick={stopClock}
+          style={{
+            padding: "6px 16px",
+            backgroundColor: "#ff4757",
+            color: "white",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+            fontFamily: "monospace",
+          }}
+          disabled={!isRunning}
+        >
+          stop
+        </button>
+        <span
+          style={{ fontSize: "0.75rem", color: "#888", alignSelf: "center" }}
+        >
+          ⌘↵
+        </span>
       </div>
 
       <textarea
@@ -134,28 +153,6 @@ function App() {
           boxSizing: "border-box",
         }}
       />
-
-      <div style={{ display: "flex", gap: "8px", margin: "8px 0" }}>
-        <button
-          onClick={() => evaluate(code)}
-          style={{
-            padding: "6px 16px",
-            backgroundColor: "#1e90ff",
-            color: "white",
-            border: "none",
-            borderRadius: "4px",
-            cursor: "pointer",
-            fontFamily: "monospace",
-          }}
-        >
-          run
-        </button>
-        <span
-          style={{ fontSize: "0.75rem", color: "#888", alignSelf: "center" }}
-        >
-          or ⌘↵
-        </span>
-      </div>
 
       <div
         style={{

--- a/packages/audio-engine/src/index.ts
+++ b/packages/audio-engine/src/index.ts
@@ -3,33 +3,63 @@ import type { DromeSchema } from "@web-audio/schema";
 import SynthesizerPlayer from "./synthesizer-player";
 
 class AudioEngine {
-  private _players: SynthesizerPlayer[];
-  private _unsubscribe: () => void;
-  private _lastScheduledBar = -1;
+  private _ctx: AudioContext;
+  private _clock: AudioClock;
+  private _players: SynthesizerPlayer[] = [];
+  // Holds retired players for one bar so their audio graph stays connected
+  // while scheduled oscillators finish playing.
+  // @ts-expect-error intentionally write-only
+  private _retiring: SynthesizerPlayer[] = [];
+  private _pending: DromeSchema | null = null;
+  private _unsubPrebar: () => void;
+  private _unsubBar: () => void;
 
-  constructor(ctx: AudioContext, clock: AudioClock, schema: DromeSchema) {
-    this._players = schema.instruments.map(
-      (inst) => new SynthesizerPlayer(ctx, clock, inst),
-    );
+  constructor(ctx: AudioContext, clock: AudioClock) {
+    this._ctx = ctx;
+    this._clock = clock;
 
-    // If the clock is already running, the next bar event may have already
-    // been dispatched by the lookahead scheduler. Pre-schedule it now so we
-    // don't silently skip a bar. The subscription skips it if it fires again.
-    if (!clock.paused) {
-      const nextBar = clock.metronome.bar + 1;
-      this._lastScheduledBar = nextBar;
-      this._players.forEach((p) => p.scheduleBar(nextBar, clock.nextBarStartTime));
-    }
+    this._unsubPrebar = clock.on("prebar", () => {
+      this._commit();
+    });
 
-    this._unsubscribe = clock.on("bar", ({ bar }, time) => {
-      if (bar <= this._lastScheduledBar) return;
-      this._lastScheduledBar = bar;
+    this._unsubBar = clock.on("bar", ({ bar }, time) => {
       this._players.forEach((p) => p.scheduleBar(bar, time));
     });
   }
 
+  update(schema: DromeSchema): void {
+    this._pending = schema;
+
+    // If the clock is paused, commit immediately so players are ready
+    // when the first bar event fires.
+    if (this._clock.paused) {
+      this._commit();
+    }
+  }
+
+  private _commit(): void {
+    // Clean up players that were retired last bar
+    this._retiring = [];
+
+    if (!this._pending) return;
+
+    // Retire current players (their scheduled audio keeps playing)
+    this._retiring = this._players;
+
+    // Create new players from the pending schema
+    this._players = this._pending.instruments.map(
+      (inst) => new SynthesizerPlayer(this._ctx, this._clock, inst),
+    );
+
+    this._pending = null;
+  }
+
   destroy(): void {
-    this._unsubscribe();
+    this._unsubPrebar();
+    this._unsubBar();
+    this._players = [];
+    this._retiring = [];
+    this._pending = null;
   }
 }
 

--- a/packages/audio-engine/src/index.ts
+++ b/packages/audio-engine/src/index.ts
@@ -13,6 +13,7 @@ class AudioEngine {
   private _pending: DromeSchema | null = null;
   private _unsubPrebar: () => void;
   private _unsubBar: () => void;
+  private _unsubStop: () => void;
 
   constructor(ctx: AudioContext, clock: AudioClock) {
     this._ctx = ctx;
@@ -24,6 +25,10 @@ class AudioEngine {
 
     this._unsubBar = clock.on("bar", ({ bar }, time) => {
       this._players.forEach((p) => p.scheduleBar(bar, time));
+    });
+
+    this._unsubStop = clock.on("stop", () => {
+      this._players.forEach((p) => p.cancelFutureNotes());
     });
   }
 
@@ -57,6 +62,7 @@ class AudioEngine {
   destroy(): void {
     this._unsubPrebar();
     this._unsubBar();
+    this._unsubStop();
     this._players = [];
     this._retiring = [];
     this._pending = null;

--- a/packages/audio-engine/src/synthesizer-player.ts
+++ b/packages/audio-engine/src/synthesizer-player.ts
@@ -3,11 +3,18 @@ import type { ParameterSchema, RandomSchema, StaticSchemaValue, SynthesizerSchem
 import RandomResolver from "./random-resolver";
 import { midiToFrequency } from "./utils/midi-to-frequency";
 
+interface ScheduledNote {
+  osc: OscillatorNode;
+  gain: GainNode;
+  startTime: number;
+}
+
 class SynthesizerPlayer {
   private _ctx: AudioContext;
   private _clock: AudioClock;
   private _schema: SynthesizerSchema;
   private _resolvers = new Map<RandomSchema, RandomResolver>();
+  private _scheduled: Set<ScheduledNote> = new Set();
 
   constructor(ctx: AudioContext, clock: AudioClock, schema: SynthesizerSchema) {
     this._ctx = ctx;
@@ -34,6 +41,18 @@ class SynthesizerPlayer {
       const detuneValue = this._resolve(this._schema.detune, barIndex, note.stepIndex);
       this._scheduleNote(note, barStartTime, detuneValue);
     });
+  }
+
+  cancelFutureNotes(): void {
+    const now = this._ctx.currentTime;
+    for (const note of this._scheduled) {
+      if (note.startTime > now) {
+        note.osc.stop(0);
+        note.osc.disconnect();
+        note.gain.disconnect();
+        this._scheduled.delete(note);
+      }
+    }
   }
 
   private _resolve(schema: ParameterSchema, barIndex: number, stepIndex: number): number {
@@ -83,9 +102,13 @@ class SynthesizerPlayer {
     osc.start(startTime);
     osc.stop(endTime + 0.5 * note.duration);
 
+    const scheduled: ScheduledNote = { osc, gain, startTime };
+    this._scheduled.add(scheduled);
+
     osc.onended = () => {
       osc.disconnect();
       gain.disconnect();
+      this._scheduled.delete(scheduled);
     };
   }
 }

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@web-audio/context",
+  "type": "module",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -96,6 +96,11 @@ function createAudioContext(options: AudioContextOptions = {}): ManagedAudioCont
     window.addEventListener(event, unlock, true);
   }
 
+  // Attempt unlock immediately — createAudioContext is likely called
+  // from within a user gesture, and the listeners above will miss
+  // the current event since it's already propagating.
+  unlock();
+
   // Set up visibility listeners
   document.addEventListener("visibilitychange", handleVisibility);
   window.addEventListener("focus", handleFocus);

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -1,0 +1,123 @@
+// Base64-encoded silent MP3 (VBR 220-260, Joint Stereo, 859 bytes).
+// Looped via an <audio> tag to force iOS onto the media channel
+// instead of the ringer channel (which the mute switch silences).
+const SILENT_MP3 =
+  "data:audio/mpeg;base64,//uQxAAAAAAAAAAAAAAAAAAAAAAAWGluZwAAAA8AAAACAAACcQCAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA//////////////////////////////////////////////////////////////////8AAABhTEFNRTMuMTAwA8MAAAAAAAAAABQgJAUHQQAB9AAAAnGMHkkIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA//sQxAADgnABGiAAQBCqgCRMAAgEAH///////////////7+n/9FTuQsQH//////2NG0jWUGlio5gLQTOtIoeR2WX////X4s9Atb/JRVCbBUpeRUq//////////////////9RUi0f2jn/+xDECgPCjAEQAABN4AAANIAAAAQVTEFNRTMuMTAwVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVQ==";
+
+const UNLOCK_EVENTS = ["click", "touchstart", "touchend", "keydown", "mousedown"] as const;
+
+interface AudioContextOptions {
+  allowBackgroundPlayback?: boolean;
+}
+
+interface ManagedAudioContext {
+  ctx: AudioContext;
+  dispose(): void;
+}
+
+function createAudioContext(options: AudioContextOptions = {}): ManagedAudioContext {
+  const { allowBackgroundPlayback = false } = options;
+
+  const ctx = new AudioContext();
+  let silentTag: HTMLAudioElement | null = null;
+  let isUnlocked = false;
+  let isBackground = false;
+  let disposed = false;
+
+  function createSilentTag(): HTMLAudioElement {
+    const audio = document.createElement("audio");
+    audio.src = SILENT_MP3;
+    audio.loop = true;
+    audio.setAttribute("x-webkit-airplay", "deny");
+    audio.disableRemotePlayback = true;
+    return audio;
+  }
+
+  function destroySilentTag() {
+    if (!silentTag) return;
+    silentTag.pause();
+    silentTag.src = "about:blank";
+    silentTag.load();
+    silentTag = null;
+  }
+
+  function unlock() {
+    if (isUnlocked || disposed) return;
+    isUnlocked = true;
+
+    ctx.resume().catch(() => {});
+
+    silentTag = createSilentTag();
+    silentTag.play().catch(() => {});
+
+    for (const event of UNLOCK_EVENTS) {
+      window.removeEventListener(event, unlock, true);
+    }
+  }
+
+  function onVisible() {
+    if (disposed || !isBackground) return;
+    isBackground = false;
+
+    ctx.resume().catch(() => {});
+
+    if (isUnlocked) {
+      silentTag = createSilentTag();
+      silentTag.play().catch(() => {});
+    }
+  }
+
+  function onHidden() {
+    if (disposed || isBackground || allowBackgroundPlayback) return;
+    isBackground = true;
+
+    ctx.suspend().catch(() => {});
+    destroySilentTag();
+  }
+
+  function handleVisibility() {
+    if (document.hidden) {
+      onHidden();
+    } else {
+      onVisible();
+    }
+  }
+
+  function handleFocus() {
+    onVisible();
+  }
+
+  function handleBlur() {
+    onHidden();
+  }
+
+  // Set up gesture listeners for unlock
+  for (const event of UNLOCK_EVENTS) {
+    window.addEventListener(event, unlock, true);
+  }
+
+  // Set up visibility listeners
+  document.addEventListener("visibilitychange", handleVisibility);
+  window.addEventListener("focus", handleFocus);
+  window.addEventListener("blur", handleBlur);
+
+  function dispose() {
+    if (disposed) return;
+    disposed = true;
+
+    for (const event of UNLOCK_EVENTS) {
+      window.removeEventListener(event, unlock, true);
+    }
+
+    document.removeEventListener("visibilitychange", handleVisibility);
+    window.removeEventListener("focus", handleFocus);
+    window.removeEventListener("blur", handleBlur);
+
+    destroySilentTag();
+    ctx.close().catch(() => {});
+  }
+
+  return { ctx, dispose };
+}
+
+export { createAudioContext, type ManagedAudioContext, type AudioContextOptions };

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["es2023", "DOM"],
+    "moduleDetection": "force",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/plans/completed/engine-queue.md
+++ b/plans/completed/engine-queue.md
@@ -1,10 +1,12 @@
 # Engine Queue: Bar-Aligned Schema Updates
 
+Status: **Complete**
+
 ## Goal
 
 Refactor AudioEngine from a create-per-eval model to a long-lived instance with
 queued, bar-aligned schema updates. Ensures re-evaluation never disrupts
-currently-playing audio.
+currently-playing audio. Cancel future-scheduled notes on stop.
 
 ## Design Decisions
 
@@ -20,14 +22,16 @@ currently-playing audio.
   ticking, the engine does nothing
 - **Empty schemas are not special-cased**: zero instruments means nothing gets
   scheduled
+- **Cancel on stop**: when the clock stops, future-scheduled notes (startTime >
+  now) are cancelled immediately; currently-sounding notes finish naturally
 
 ## Implementation
 
-### 1. Refactor AudioEngine (`packages/audio-engine/src/index.ts`)
+### 1. Refactor AudioEngine (`packages/audio-engine/src/index.ts`) — Done
 
 **Constructor** changes from `(ctx, clock, schema)` to `(ctx, clock)`:
 - Stores `ctx` and `clock`
-- Subscribes to `prebar` and `bar` events
+- Subscribes to `prebar`, `bar`, and `stop` events
 - No players created yet
 
 **`update(schema: DromeSchema)`**:
@@ -36,22 +40,34 @@ currently-playing audio.
   has players ready
 
 **`prebar` handler (commit phase)**:
+- Clean up players retired from the previous bar
 - If `this._pending` exists:
   - Move current `_players` to `_retiring` list
   - Create new `_players` from `this._pending`
   - Clear `this._pending`
-- If `_retiring` has players from a previous swap (one bar has passed), clean
-  them up (currently a no-op since oscillators self-disconnect via `onended`,
-  but this is where future cleanup like disconnecting effect chains would go)
 
 **`bar` handler (apply phase)**:
-- Schedule all current `_players` for this bar (same as today)
+- Schedule all current `_players` for this bar
+
+**`stop` handler**:
+- Calls `cancelFutureNotes()` on all active players
 
 **`destroy()`**:
-- Unsubscribes from clock events
+- Unsubscribes from all clock events
 - Clears players and retiring list
 
-### 2. Update App (`apps/sequencer/src/App.tsx`)
+### 2. Cancel Future Notes (`packages/audio-engine/src/synthesizer-player.ts`) — Done
+
+**`ScheduledNote` tracking**:
+- Each scheduled oscillator/gain pair is tracked in a `Set<ScheduledNote>` with
+  its `startTime`
+- Self-removes via `onended` callback when the note finishes naturally
+
+**`cancelFutureNotes()`**:
+- Iterates tracked notes, stops and disconnects any where `startTime > ctx.currentTime`
+- Currently-sounding notes are left alone to finish naturally
+
+### 3. Update App (`apps/sequencer/src/App.tsx`) — Done
 
 **`getEngine()`** — lazy initializer like `getAudio()` and `getClock()`:
 - Creates `new AudioEngine(getAudio().ctx, getClock())`
@@ -63,15 +79,16 @@ currently-playing audio.
 - Starts clock if not running
 
 **`stopClock()`**:
-- Stops the clock
+- Stops the clock (engine reacts via stop event)
 - Does NOT destroy the engine
 
 **Cleanup effect**:
 - Calls `engineRef.current?.destroy()` on unmount
 
-### 3. Files Changed
+### 4. Files Changed
 
 | File | Change |
 |------|--------|
-| `packages/audio-engine/src/index.ts` | Rewrite constructor, add `update()`, add `prebar`/`bar` handlers, retiring queue |
+| `packages/audio-engine/src/index.ts` | Rewrite constructor, add `update()`, `prebar`/`bar`/`stop` handlers, retiring queue |
+| `packages/audio-engine/src/synthesizer-player.ts` | Track scheduled notes, add `cancelFutureNotes()` |
 | `apps/sequencer/src/App.tsx` | Long-lived engine via `getEngine()`, simplified `evaluate()` and `stopClock()` |

--- a/plans/engine-queue.md
+++ b/plans/engine-queue.md
@@ -1,0 +1,77 @@
+# Engine Queue: Bar-Aligned Schema Updates
+
+## Goal
+
+Refactor AudioEngine from a create-per-eval model to a long-lived instance with
+queued, bar-aligned schema updates. Ensures re-evaluation never disrupts
+currently-playing audio.
+
+## Design Decisions
+
+- **Engine is long-lived**: created once with `ctx` and `clock`, persists across
+  start/stop cycles
+- **`update(schema)` queues a pending schema**: last write wins within a bar
+- **`prebar` callback commits**: creates new players from pending schema, retires
+  old players (without disconnecting their audio graph)
+- **`bar` callback applies**: schedules notes with the new players
+- **One-bar grace period**: retired players are cleaned up at the next `prebar`
+  after they stop scheduling (upgrade to self-reporting when envelopes land)
+- **Engine is clock-reactive**: no stop/start API needed — if the clock isn't
+  ticking, the engine does nothing
+- **Empty schemas are not special-cased**: zero instruments means nothing gets
+  scheduled
+
+## Implementation
+
+### 1. Refactor AudioEngine (`packages/audio-engine/src/index.ts`)
+
+**Constructor** changes from `(ctx, clock, schema)` to `(ctx, clock)`:
+- Stores `ctx` and `clock`
+- Subscribes to `prebar` and `bar` events
+- No players created yet
+
+**`update(schema: DromeSchema)`**:
+- Sets `this._pending = schema`
+- If clock is paused (first run), commit immediately so the first `bar` event
+  has players ready
+
+**`prebar` handler (commit phase)**:
+- If `this._pending` exists:
+  - Move current `_players` to `_retiring` list
+  - Create new `_players` from `this._pending`
+  - Clear `this._pending`
+- If `_retiring` has players from a previous swap (one bar has passed), clean
+  them up (currently a no-op since oscillators self-disconnect via `onended`,
+  but this is where future cleanup like disconnecting effect chains would go)
+
+**`bar` handler (apply phase)**:
+- Schedule all current `_players` for this bar (same as today)
+
+**`destroy()`**:
+- Unsubscribes from clock events
+- Clears players and retiring list
+
+### 2. Update App (`apps/sequencer/src/App.tsx`)
+
+**`getEngine()`** — lazy initializer like `getAudio()` and `getClock()`:
+- Creates `new AudioEngine(getAudio().ctx, getClock())`
+- Engine persists for the lifetime of the app
+
+**`evaluate()`**:
+- Builds schema from code
+- Calls `getEngine().update(schema)`
+- Starts clock if not running
+
+**`stopClock()`**:
+- Stops the clock
+- Does NOT destroy the engine
+
+**Cleanup effect**:
+- Calls `engineRef.current?.destroy()` on unmount
+
+### 3. Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/audio-engine/src/index.ts` | Rewrite constructor, add `update()`, add `prebar`/`bar` handlers, retiring queue |
+| `apps/sequencer/src/App.tsx` | Long-lived engine via `getEngine()`, simplified `evaluate()` and `stopClock()` |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@web-audio/clock':
         specifier: workspace:*
         version: link:../../packages/clock
+      '@web-audio/context':
+        specifier: workspace:*
+        version: link:../../packages/context
       '@web-audio/fluid':
         specifier: workspace:*
         version: link:../../packages/fluid
@@ -143,6 +146,8 @@ importers:
       vitest:
         specifier: ^4.1.2
         version: 4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
+
+  packages/context: {}
 
   packages/eslint-config:
     devDependencies:


### PR DESCRIPTION
## Summary
- Add `@web-audio/context` package with managed AudioContext (iOS silent audio tag, gesture gating, visibility-based suspend/resume)
- Refactor AudioEngine to a long-lived, queue-based model: `update(schema)` queues changes, committed at bar boundaries via `prebar`/`bar` clock events
- Cancel future-scheduled notes on clock stop (currently-sounding notes finish naturally)
- Simplify sequencer UI to run/stop buttons; context, clock, and engine are all long-lived

## Test plan
- [x] Typecheck passes
- [x] All 17 audio-engine tests pass
- [x] Verify on iOS: audio plays on first "run" tap, respects mute switch behavior, suspends on background
- [x] Verify re-evaluation mid-playback transitions cleanly at bar boundary
- [x] Verify stop cancels future notes without cutting currently-sounding ones