### PR TITLE
Rename sampler and envelope modes

### DIFF
--- a/docs/concepts/developer-terms.md
+++ b/docs/concepts/developer-terms.md
@@ -127,4 +127,4 @@ The in-memory decoded audio data used to play a sample. Can be derived from an a
 
 ### Envelope mode
 
-Controls how ADSR stages map onto note duration: `bleed` (default) or `clip`.
+Controls how ADSR stages map onto note duration: `bleed` (default) or `bounded`.

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -224,5 +224,4 @@ Range sets the minimum and maximum values that random generation can produce. It
 
 ### Notes
 
-- [x] Renamed `durationMode` to `clipMode` throughout the codebase
 - We will in the near future be adding a Supersaw waveform/worklet option for synths, as well as the following effects: Pan (left/right positioning), Delay (echo with feedback), Reverb (algorithmic/convolution space), and Distortion (harmonic saturation), Bitcrusher

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -139,7 +139,10 @@ Fit is a sampler mode where playback duration is adjusted to span a fixed number
 
 ### Clip mode
 
-Clip mode controls whether a sample stops at its scheduled step boundary or plays until it finishes naturally (i.e. until the audio file ends).
+Clip mode (`clipMode`) controls whether a sample stops at its scheduled step boundary or plays through to completion.
+
+- **`"clipped"`**: The sample stops exactly when its step in the pattern ends, regardless of the actual audio duration.
+- **`"one-shot"`**: The sample plays to its natural duration and stops there (non-looping).
 
 ### Loop mode
 
@@ -221,5 +224,5 @@ Range sets the minimum and maximum values that random generation can produce. It
 
 ### Notes
 
-- Code update: should we rename durationMode to clipMode in the code?
+- [x] Renamed `durationMode` to `clipMode` throughout the codebase
 - We will in the near future be adding a Supersaw waveform/worklet option for synths, as well as the following effects: Pan (left/right positioning), Delay (echo with feedback), Reverb (algorithmic/convolution space), and Distortion (harmonic saturation), Bitcrusher

--- a/notes/snippets.js
+++ b/notes/snippets.js
@@ -45,12 +45,12 @@ d.synth("saw")
 d.synth("saw")
   .root("c4")
   .scale("min")
-  .notes([0, 2, 4, 0], [0, 0, 0, 0])
+  .notes([0, 4, 2, 0, 5, 4, 2, 0], [0, 0, 0, 0, 0, 0, 0, 0])
   .detune(d.lfo(0, [0, 400, 0, -400]).wave("saw").norm())
-  .adsr(0.05, 1, 0.333, 1)
+  .adsr(0.1, 1, 0.333, 0.5)
   .fx(
     d.lpf(d.env(200, 1600).adsr(0.25, 0.5, 0.25, 0.5)),
-    d.lpf(d.lfo(200, 2400).wave("saw").speed(0.5).norm()),
+    d.lpf(d.lfo(800, 3200).wave("saw").speed(0.5).norm()),
   )
   .push();
 
@@ -90,3 +90,28 @@ d.sample("bd").bank("user").hex(0xf).push();
 
 // Multiple Variations
 d.sample("bd").var([0, 1, 2, 3]).bank("tr909").hex(0xf).push();
+
+// Plane noodling
+const r = "c";
+const s = "min";
+
+d.synth("saw")
+  .root(r + 4)
+  .scale(s)
+  .notes([0, 4, 2, 0, 5, 4, 2, 0], [0, 0, 0, 0, 0, 0, 0, 0])
+  .detune(d.lfo(0, [0, 400, 0, -400]).wave("saw").norm())
+  .adsr(0.05, 1, 0.333, 0.5)
+  .fx(
+    d.lpf(d.env(200, 1600).adsr(0.25, 0.5, 0.25, 0.5)),
+    d.lpf(d.lfo(800, 3200).wave("saw").speed(0.5).norm()),
+  )
+  .push();
+
+d.synth("saw")
+  .root(r + 2)
+  .scale(s)
+  .notes(0, 2, 3, -2)
+  .stretch(4, 8)
+  .adsr(0, 0.5, 0.75, 0.5)
+  .fx(d.lpf(d.env(100, 400).adsr(0.25, 0.5, 0.125, 0.5)))
+  .push();

--- a/notes/snippets.js
+++ b/notes/snippets.js
@@ -47,7 +47,7 @@ d.synth("saw")
   .scale("min")
   .notes([0, 2, 4, 0], [0, 0, 0, 0])
   .detune(d.lfo(0, [0, 400, 0, -400]).wave("saw").norm())
-  .adsr(0, 1, 0.333, 1)
+  .adsr(0.05, 1, 0.333, 1)
   .fx(
     d.lpf(d.env(200, 1600).adsr(0.25, 0.5, 0.25, 0.5)),
     d.lpf(d.lfo(200, 2400).wave("saw").speed(0.5).norm()),

--- a/packages/audio-engine/src/engine.test.ts
+++ b/packages/audio-engine/src/engine.test.ts
@@ -130,7 +130,7 @@ function makeSamplerSchema(): DromeSchema {
         },
         effects: [],
         loop: false,
-        durationMode: "clip",
+        clipMode: "clipped",
       },
     ],
     banks: {

--- a/packages/audio-engine/src/instruments/instrument.test.ts
+++ b/packages/audio-engine/src/instruments/instrument.test.ts
@@ -233,10 +233,10 @@ describe("Instrument._computeTimings", () => {
     expect(result.releaseDur).toBeCloseTo(1.0 * 2);
   });
 
-  it("clip mode — normalizes a+d+r together when they exceed 1", () => {
+  it("bounded mode — normalizes a+d+r together when they exceed 1", () => {
     // a=0.5, d=0.5, r=0.5 → adrSum=1.5 → each becomes 1/3
     const result = makeInstrument().computeTimings(
-      makeEnvelope(0.5, 0.5, 0.5, 0.5, "clip"),
+      makeEnvelope(0.5, 0.5, 0.5, 0.5, "bounded"),
       0,
       0,
       3,

--- a/packages/audio-engine/src/instruments/sampler.test.ts
+++ b/packages/audio-engine/src/instruments/sampler.test.ts
@@ -177,7 +177,7 @@ function makeSchema(overrides: Partial<SamplerSchema> = {}): SamplerSchema {
     gain: envelope(),
     effects: [],
     loop: false,
-    durationMode: "clip",
+    clipMode: "clipped",
     ...overrides,
   };
 }
@@ -684,7 +684,7 @@ describe("Sampler", () => {
       ctx as unknown as AudioContext,
       clock as never,
       {
-        schema: makeSchema({ notes, durationMode: "one-shot" }),
+        schema: makeSchema({ notes, clipMode: "one-shot" }),
         banks: makeBanks(url),
         cache,
       },

--- a/packages/audio-engine/src/instruments/sampler.ts
+++ b/packages/audio-engine/src/instruments/sampler.ts
@@ -178,7 +178,7 @@ class Sampler extends Instrument {
     const noteDuration = note.duration * barDuration;
     const sampleDuration = buffer.duration / note.value;
     const duration =
-      this._schema.durationMode === "one-shot" && !this._schema.loop
+      this._schema.clipMode === "one-shot" && !this._schema.loop
         ? sampleDuration
         : noteDuration;
     const endTime = startTime + duration;

--- a/packages/audio-engine/src/utils/normalize.test.ts
+++ b/packages/audio-engine/src/utils/normalize.test.ts
@@ -98,7 +98,7 @@ describe("normalizeADSR", () => {
     });
   });
 
-  describe("clip mode", () => {
+  describe("bounded mode", () => {
     it("passes through A, D, and R unchanged when their sum is already <= 1", () => {
       const result = normalizeADSR({
         a: 0.2,
@@ -107,7 +107,7 @@ describe("normalizeADSR", () => {
         r: 0.1,
         min: 0,
         max: 1,
-        mode: "clip",
+        mode: "bounded",
       });
       expect(result.a).toBe(0.2);
       expect(result.d).toBe(0.1);
@@ -122,7 +122,7 @@ describe("normalizeADSR", () => {
         r: 0.4,
         min: 0,
         max: 1,
-        mode: "clip",
+        mode: "bounded",
       });
       expect(result.a + result.d + result.r).toBeCloseTo(1);
     });
@@ -135,7 +135,7 @@ describe("normalizeADSR", () => {
         r: 0.4,
         min: 0,
         max: 1,
-        mode: "clip",
+        mode: "bounded",
       });
       expect(result.a / result.r).toBeCloseTo(0.5 / 0.4);
       expect(result.a / result.d).toBeCloseTo(0.5 / 0.3);
@@ -149,7 +149,7 @@ describe("normalizeADSR", () => {
         r: 0.4,
         min: 0,
         max: 1,
-        mode: "clip",
+        mode: "bounded",
       });
       expect(result.s).toBe(0.8);
     });
@@ -172,7 +172,7 @@ describe("normalizeADSR", () => {
       expect(result.r).toBe(0);
     });
 
-    it("handles all zeros in clip mode without dividing by zero", () => {
+    it("handles all zeros in bounded mode without dividing by zero", () => {
       const result = normalizeADSR({
         a: 0,
         d: 0,
@@ -180,7 +180,7 @@ describe("normalizeADSR", () => {
         r: 0,
         min: 0,
         max: 1,
-        mode: "clip",
+        mode: "bounded",
       });
       expect(result.a).toBe(0);
       expect(result.d).toBe(0);
@@ -201,7 +201,7 @@ describe("normalizeADSR", () => {
       expect(result.d).toBeCloseTo(0);
     });
 
-    it("handles a single dominant value in clip mode", () => {
+    it("handles a single dominant value in bounded mode", () => {
       const result = normalizeADSR({
         a: 3,
         d: 0,
@@ -209,7 +209,7 @@ describe("normalizeADSR", () => {
         r: 0,
         min: 0,
         max: 1,
-        mode: "clip",
+        mode: "bounded",
       });
       expect(result.a).toBeCloseTo(1);
       expect(result.d).toBeCloseTo(0);

--- a/packages/fluid/src/automations/envelope.test.ts
+++ b/packages/fluid/src/automations/envelope.test.ts
@@ -154,8 +154,8 @@ describe("Envelope", () => {
       expect(new Envelope().getSchema().mode).toBe("bleed");
     });
 
-    it("sets clip mode", () => {
-      expect(new Envelope().mode("clip").getSchema().mode).toBe("clip");
+    it("sets bounded mode", () => {
+      expect(new Envelope().mode("bounded").getSchema().mode).toBe("bounded");
     });
   });
 
@@ -167,7 +167,7 @@ describe("Envelope", () => {
       expect(env.d(0.1)).toBe(env);
       expect(env.s(0.8)).toBe(env);
       expect(env.r(0.1)).toBe(env);
-      expect(env.mode("clip")).toBe(env);
+      expect(env.mode("bounded")).toBe(env);
     });
   });
 });

--- a/packages/fluid/src/automations/envelope.ts
+++ b/packages/fluid/src/automations/envelope.ts
@@ -9,7 +9,7 @@ class Envelope {
   private _d: Parameter;
   private _s: Parameter;
   private _r: Parameter;
-  private _mode: "bleed" | "clip";
+  private _mode: "bleed" | "bounded";
 
   constructor(min?: number, ...max: CycleInput) {
     this._min = min ?? 0;
@@ -54,7 +54,7 @@ class Envelope {
     return this;
   }
 
-  mode(m: "bleed" | "clip") {
+  mode(m: "bleed" | "bounded") {
     this._mode = m;
     return this;
   }

--- a/packages/fluid/src/index.test.ts
+++ b/packages/fluid/src/index.test.ts
@@ -62,13 +62,13 @@ describe("Drome", () => {
 
     it("accepts an Envelope instance", () => {
       const d = new Drome();
-      const env = d.env(0, 0.5).adsr(0.5, 0.25, 0.8, 0.1).mode("clip");
+      const env = d.env(0, 0.5).adsr(0.5, 0.25, 0.8, 0.1).mode("bounded");
       d.synth("triangle").gain(env).push();
       const { gain } = d.getSchema().instruments[0];
 
       expect(gain.type).toBe("envelope");
       expect(gain.min).toBe(0);
-      expect(gain.mode).toBe("clip");
+      expect(gain.mode).toBe("bounded");
       if (gain.max.type === "static") {
         expect(gain.max.cycle[0][0].value).toBe(0.5);
       }
@@ -262,7 +262,7 @@ describe("Drome", () => {
     it("each instrument schema is independent", () => {
       const d = new Drome();
       d.synth("sine").gain(0.5).push();
-      d.synth("triangle").gain(d.env(0, 1).mode("clip")).push();
+      d.synth("triangle").gain(d.env(0, 1).mode("bounded")).push();
 
       const [sine, triangle] = d.getSchema().instruments;
 
@@ -270,7 +270,7 @@ describe("Drome", () => {
         expect(sine.gain.max.cycle[0][0].value).toBe(0.5);
       }
       expect(sine.gain.mode).toBe("bleed");
-      expect(triangle.gain.mode).toBe("clip");
+      expect(triangle.gain.mode).toBe("bounded");
     });
   });
 

--- a/packages/fluid/src/index.test.ts
+++ b/packages/fluid/src/index.test.ts
@@ -286,7 +286,7 @@ describe("Drome", () => {
         expect(inst.bank).toBe("tr909");
         expect(inst.sample).toBe("bd");
         expect(inst.loop).toBe(false);
-        expect(inst.durationMode).toBe("clip");
+        expect(inst.clipMode).toBe("clipped");
         expect(inst.variation.type).toBe("static");
         expect(inst.notes).not.toHaveProperty("type", "fit");
       }
@@ -376,36 +376,36 @@ describe("Drome", () => {
       }
     });
 
-    it("clip(false) sets sampler duration mode to one-shot", () => {
+    it("clip(false) sets sampler clip mode to one-shot", () => {
       const d = new Drome();
       d.sample("oh").clip(false).push();
       const inst = d.getSchema().instruments[0];
 
       expect(inst.type).toBe("sampler");
       if (inst.type === "sampler") {
-        expect(inst.durationMode).toBe("one-shot");
+        expect(inst.clipMode).toBe("one-shot");
       }
     });
 
-    it("clip() sets sampler duration mode to clip", () => {
+    it("clip() sets sampler clip mode to clipped", () => {
       const d = new Drome();
       d.sample("oh").clip(false).clip().push();
       const inst = d.getSchema().instruments[0];
 
       expect(inst.type).toBe("sampler");
       if (inst.type === "sampler") {
-        expect(inst.durationMode).toBe("clip");
+        expect(inst.clipMode).toBe("clipped");
       }
     });
 
-    it("clip(true) sets sampler duration mode to clip", () => {
+    it("clip(true) sets sampler clip mode to clipped", () => {
       const d = new Drome();
       d.sample("oh").clip(false).clip(true).push();
       const inst = d.getSchema().instruments[0];
 
       expect(inst.type).toBe("sampler");
       if (inst.type === "sampler") {
-        expect(inst.durationMode).toBe("clip");
+        expect(inst.clipMode).toBe("clipped");
       }
     });
 

--- a/packages/fluid/src/instruments/sampler.ts
+++ b/packages/fluid/src/instruments/sampler.ts
@@ -2,8 +2,8 @@ import SampleNotes from "@/patterns/sample-notes";
 import Parameter from "@/patterns/parameter";
 import type { CycleInput } from "@/types";
 import type {
+  ClipMode,
   FitSchema,
-  SamplerDurationMode,
   SamplerSchema,
 } from "@web-audio/schema";
 import { DEFAULT_BANK } from "@/banks";
@@ -21,7 +21,7 @@ class Sampler extends Instrument {
   private _variation: Parameter;
   private _fit: FitSchema | null = null;
   private _loop = false;
-  private _durationMode: SamplerDurationMode = "clip";
+  private _clipMode: ClipMode = "clipped";
 
   constructor(
     sample: string,
@@ -66,7 +66,7 @@ class Sampler extends Instrument {
   }
 
   clip(enabled = true) {
-    this._durationMode = enabled ? "clip" : "one-shot";
+    this._clipMode = enabled ? "clipped" : "one-shot";
     return this;
   }
 
@@ -81,7 +81,7 @@ class Sampler extends Instrument {
       gain: this._gain.getSchema(),
       effects: this._effects.map((e) => e.getSchema()),
       loop: this._loop,
-      durationMode: this._durationMode,
+      clipMode: this._clipMode,
     };
   }
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -4,7 +4,7 @@
 
 type Waveform = "sine" | "square" | "sawtooth" | "triangle";
 
-type EnvelopeMode = "bleed" | "clip";
+type EnvelopeMode = "bleed" | "bounded";
 
 type ClipMode = "clipped" | "one-shot";
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -6,7 +6,7 @@ type Waveform = "sine" | "square" | "sawtooth" | "triangle";
 
 type EnvelopeMode = "bleed" | "clip";
 
-type SamplerDurationMode = "clip" | "one-shot";
+type ClipMode = "clipped" | "one-shot";
 
 type FilterType = "lp" | "hp" | "bp" | "notch" | "ap" | "pk" | "ls" | "hs";
 
@@ -128,7 +128,7 @@ interface SamplerSchema extends InstrumentSchema {
   variation: ParameterSchema;
   notes: ParameterSchema | FitSchema;
   loop: boolean;
-  durationMode: SamplerDurationMode;
+  clipMode: ClipMode;
 }
 
 // ---------------------------------------------------
@@ -144,6 +144,7 @@ interface DromeSchema {
 export type {
   BankDefinition,
   BankSchema,
+  ClipMode,
   DromeSchema,
   EffectSchema,
   EnvelopeMode,
@@ -156,7 +157,6 @@ export type {
   LfoSchema,
   ParameterSchema,
   RandomSchema,
-  SamplerDurationMode,
   SamplerSchema,
   StaticSchema,
   StaticSchemaValue,

--- a/plans/completed/effects-filter-prd.md
+++ b/plans/completed/effects-filter-prd.md
@@ -141,7 +141,7 @@ Filter envelopes use `_scheduleParamEnvelope(param, envelope, barIndex, stepInde
 - If envelope: call `_scheduleParamEnvelope` on the target AudioParam
 - If parameter: resolve to a static number via `_resolve`, set value once at note start
 
-Normalization (bleed/clip modes) applies identically to filter envelopes — the ADSR shape is always relative to note duration regardless of target param.
+Normalization (bleed/bounded modes) applies identically to filter envelopes — the ADSR shape is always relative to note duration regardless of target param.
 
 Engine clamps computed A and R to a minimum of 5ms absolute to prevent artifacts.
 

--- a/plans/completed/gain-and-envelope-plan.md
+++ b/plans/completed/gain-and-envelope-plan.md
@@ -25,7 +25,7 @@ interface EnvelopeSchema {
   d: ParameterSchema;
   s: ParameterSchema;
   r: ParameterSchema;
-  mode: "bleed" | "clip";
+  mode: "bleed" | "bounded";
 }
 ```
 
@@ -76,11 +76,11 @@ Replace the existing stub. The `Envelope` class:
 - Constructor: `(min?: number, ...max: CycleInput)` — defaults min=0, max=1
 - Stores `_min: number` and `_max: Parameter` (reuses existing `Parameter` class)
 - ADSR fields: `_a`, `_d`, `_s`, `_r` — each a `Parameter` instance, defaults: A=0.01, D=0, S=1, R=0.01
-- `_mode`: `"bleed" | "clip"`, default `"bleed"`
+- `_mode`: `"bleed" | "bounded"`, default `"bleed"`
 - Chainable setters:
   - `.adsr(a, d, s, r)` — each arg is `number | number[]`. Creates new `Parameter` for each.
   - `.a(...input)`, `.d(...)`, `.s(...)`, `.r(...)` — individual setters, same input signature as `Parameter` constructor
-  - `.mode(m: "bleed" | "clip")`
+  - `.mode(m: "bleed" | "bounded")`
 - `.getSchema(): EnvelopeSchema` — calls `.getSchema()` on each internal `Parameter` to produce the full `EnvelopeSchema`
 
 **Acceptance criteria:**
@@ -88,7 +88,7 @@ Replace the existing stub. The `Envelope` class:
 - `new Envelope().getSchema()` returns a valid `EnvelopeSchema` with all defaults
 - `new Envelope(0, 0.75).adsr(0.5, 0.25, 0.1, 0.1).getSchema()` returns correct schema
 - Individual setters override `.adsr()` (last write wins)
-- `.mode("clip")` is reflected in schema
+- `.mode("bounded")` is reflected in schema
 
 **Testing:** Unit tests in `packages/fluid/src/automations/envelope.test.ts`:
 
@@ -96,7 +96,7 @@ Replace the existing stub. The `Envelope` class:
 - Custom min/max
 - `.adsr()` sets all four
 - Individual `.a()`, `.d()`, `.s()`, `.r()` override
-- `.mode("clip")`
+- `.mode("bounded")`
 - Cycle/array inputs on max and ADSR params
 - RandomCycle input on max
 
@@ -216,21 +216,21 @@ function normalizeADSR(
   d: number,
   s: number,
   r: number,
-  mode: "bleed" | "clip",
+  mode: "bleed" | "bounded",
 ): NormalizedADSR;
 ```
 
 Rules:
 
 - **Bleed mode:** A + D normalized to sum ≤ 1 (proportional scaling). R is a separate proportion, capped at ≤ 1.
-- **Clip mode:** A + D + R normalized to sum ≤ 1 (proportional scaling).
+- **Bounded mode:** A + D + R normalized to sum ≤ 1 (proportional scaling).
 - S is a sustain level (0–1), not a duration — passed through unchanged.
 
 **Acceptance criteria:**
 
 - Bleed: `normalizeADSR(0.6, 0.6, 0.8, 0.5, "bleed")` → A=0.5, D=0.5, S=0.8, R=0.5
 - Bleed: `normalizeADSR(0.3, 0.2, 0.8, 0.5, "bleed")` → unchanged (A+D already ≤ 1)
-- Clip: `normalizeADSR(0.5, 0.3, 0.8, 0.4, "clip")` → A+D+R scaled to sum to 1
+- Bounded: `normalizeADSR(0.5, 0.3, 0.8, 0.4, "bounded")` → A+D+R scaled to sum to 1
 - S passed through unchanged in all cases
 
 **Testing:** `packages/audio-engine/src/utils/normalize.test.ts`:
@@ -238,8 +238,8 @@ Rules:
 - Bleed: A+D already ≤ 1 (no change)
 - Bleed: A+D > 1 (proportional scaling)
 - Bleed: R > 1 (capped to 1)
-- Clip: A+D+R already ≤ 1 (no change)
-- Clip: A+D+R > 1 (proportional scaling)
+- Bounded: A+D+R already ≤ 1 (no change)
+- Bounded: A+D+R > 1 (proportional scaling)
 - Edge cases: all zeros, single value dominates
 
 ---
@@ -296,7 +296,7 @@ Replace the hardcoded gain ramp with envelope-driven scheduling:
 3. Apply `BASE_GAIN = 0.25` multiplier to all gain values (engine-level concern, prevents clipping)
 4. Compute absolute durations: `Math.max(a * noteDuration, 0.005)` for attack, decay, release — 5ms minimum prevents popping
 5. Schedule `GainNode` automation: min → max (attack) → sustain level (decay) → hold → min (release)
-6. Bleed mode: oscillator stop time extends past note end to cover release tail; clip mode: stop time is at note end
+6. Bleed mode: oscillator stop time extends past note end to cover release tail; bounded mode: stop time is at note end
 
 **Acceptance criteria:**
 

--- a/plans/completed/gain-and-envelope.md
+++ b/plans/completed/gain-and-envelope.md
@@ -21,7 +21,7 @@ d.synth("triangle").gain([0.75, 1.25], [0.25, 0.5]).push();
 const env = d
   .env(0, 0.75) // min and max (defaults: 0, 1). Max accepts cycle syntax.
   .adsr(0.5, 0.25, 0.1, 0.1) // set all four. Each arg: number or single-bar cycle.
-  .mode("bleed"); // "bleed" (default) or "clip"
+  .mode("bleed"); // "bleed" (default) or "bounded"
 
 d.synth("triangle").gain(env).push();
 ```
@@ -64,7 +64,7 @@ interface EnvelopeSchema {
   d: ParameterSchema;
   s: ParameterSchema;
   r: ParameterSchema;
-  mode: "bleed" | "clip";
+  mode: "bleed" | "bounded";
 }
 
 // Updated — already exists in @web-audio/schema
@@ -105,7 +105,7 @@ interface SynthesizerSchema {
 ### Normalization (done in the fluid layer)
 
 - **Bleed mode:** A + D normalized to sum ≤ 1 (fit within note). R is a separate proportion of note duration, applied after the note ends.
-- **Clip mode:** A + D + R all normalized to sum ≤ 1 (fit within note).
+- **Bounded mode:** A + D + R all normalized to sum ≤ 1 (fit within note).
 - Normalization uses straight proportional scaling (divide each by their sum).
 
 ### Engine safety

--- a/plans/sampler-plan.md
+++ b/plans/sampler-plan.md
@@ -68,7 +68,7 @@ interface SynthesizerSchema extends InstrumentSchema {
   notes: ParameterSchema;
 }
 
-type SamplerDurationMode = "clip" | "one-shot";
+type clipMode = "clipped" | "one-shot";
 
 interface SamplerSchema extends InstrumentSchema {
   type: "sampler";

--- a/plans/sampler-plan.md
+++ b/plans/sampler-plan.md
@@ -8,7 +8,7 @@ The audio system currently has a single instrument type — `Synthesizer` — wh
 
 - A "note" for the sampler is a **playback rate** (float), not a frequency. The `Sampler` fluid class uses a `SamplerNotes` helper that converts MIDI pitch + root to a playback rate multiplier at schema build time (`2^((note - root) / 12)`). Root does not appear in the schema.
 - Sample loading is **JIT** — the engine waits for all required samples to be loaded before the clock starts. If a sample is added mid-playback, the instrument is silently skipped until its sample is ready (console warning emitted on each miss).
-- Sample playback defaults to **clipped** note-duration behavior for backwards compatibility. Fluid exposes `.clip()`, `.clip(true)`, and `.clip(false)`; disabling clip emits `durationMode: "one-shot"`, allowing non-looping samples to play through their natural buffer duration.
+- Sample playback defaults to **clipped** note-duration behavior for backwards compatibility. Fluid exposes `.clip()`, `.clip(true)`, and `.clip(false)`; disabling clip emits `clipMode: "one-shot"`, allowing non-looping samples to play through their natural buffer duration.
 - Built-in sample banks are hosted on a **self-hosted CDN**. Bank manifests are defined as TypeScript constants in `packages/fluid/src/data/banks.ts` with full CDN URLs. Fluid inlines them into `DromeSchema.banks` at schema-build time — the engine reads URLs from the schema and has no CDN awareness.
 - The reserved bank name `"user"` is the destination for `loadSamples({ name: ... })` calls using the flat (no-name) format.
 - `fit(bars)` cannot be resolved in fluid (requires sample duration from the loaded buffer), so it is a first-class `FitSchema` value in the schema — the only exception to the fluid-smart principle.
@@ -77,7 +77,7 @@ interface SamplerSchema extends InstrumentSchema {
   variation: ParameterSchema;
   notes: ParameterSchema | FitSchema;
   loop: boolean;
-  durationMode: SamplerDurationMode;
+  clipMode: ClipMode;
 }
 ```
 
@@ -89,7 +89,7 @@ interface SamplerSchema extends InstrumentSchema {
 - [x] `SamplerSchema` extends `InstrumentSchema` and is exported
 - [x] `SynthesizerSchema` extends `InstrumentSchema`
 - [x] `notes` accepts both `ParameterSchema` and `FitSchema`
-- [x] `durationMode` accepts `"clip" | "one-shot"`
+- [x] `clipMode` accepts `"clipped" | "one-shot"`
 - [x] Package type-checks cleanly
 
 **Testing:**
@@ -284,7 +284,7 @@ If a bank name is not found in either source, fluid logs a warning and omits it 
 - [x] `.fit(2)` sets `notes` to `{ type: "fit", bars: 2 }` in the schema
 - [x] Calling `.notes([0])` after `.fit(2)` uses the note ParameterSchema (fit is cleared)
 - [x] `.loop(true)` sets `loop: true` in the schema
-- [x] `.clip()`, `.clip(true)`, and `.clip(false)` set `durationMode` appropriately
+- [x] `.clip()`, `.clip(true)`, and `.clip(false)` set `clipMode` appropriately
 - [x] `.gain()`, `.fx()`, `.root()`, `.scale()` all work identically to `Synthesizer`
 - [x] `_host` and `push()` live in `Instrument` base — not duplicated in subclasses
 - [x] `Instrument` is abstract with `abstract getSchema()`
@@ -297,7 +297,7 @@ If a bank name is not found in either source, fluid logs a warning and omits it 
 - [x] `d.sample("loop").fit(2).notes([0]).getSchema()` → `notes` is a `ParameterSchema` (not FitSchema)
 - [x] `d.sample("bd").root("A4").notes([0]).getSchema()` → `notes` has value `1.0`
 - [x] `d.sample("bd").root("A4").notes([12]).getSchema()` → `notes` has value `2.0`
-- [x] `d.sample("oh").clip(false).getSchema()` → `durationMode: "one-shot"`
+- [x] `d.sample("oh").clip(false).getSchema()` → `clipMode: "one-shot"`
 
 ---
 
@@ -465,7 +465,7 @@ node.stop(stopTime);
 - [x] `d.sample("bd").getSchema()` — valid `SamplerSchema` in `instruments[]`
 - [x] `d.sample("bd").bank("tr808").root("A4").notes([0, 3, 7]).getSchema()` — notes field is a ParameterSchema with float rates
 - [x] `d.sample("loop").fit(2).loop(true).getSchema()` — `notes` is `FitSchema`, `loop: true`
-- [x] `d.sample("oh").clip(false).getSchema()` — `durationMode: "one-shot"`
+- [x] `d.sample("oh").clip(false).getSchema()` — `clipMode: "one-shot"`
 - [x] `d.sample("bd").gain(d.env(0, 1)).fx(d.lpf(800)).getSchema()` — gain and effects present
 - [x] Mixed schema: synth + sampler both in `instruments[]`
 


### PR DESCRIPTION
## Summary
- rename sampler schema durationMode to clipMode
- use clipped/one-shot values for sampler clip behavior
- rename envelope mode clip to bounded to avoid terminology overlap
- update tests, docs, plans, and snippets for the new terminology

## Stack
- stacked on #25 / plan-cleanup

## Validation
- pnpm check
- pnpm test
- pnpm lint