### PR TITLE
Fix ATProto OAuth dev session restore

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
 	"dependencies": {
 		"@atproto/common-web": "^0.4.21",
 		"@atproto/lex": "^0.0.25",
+		"@atproto/oauth-client": "0.6.1",
 		"@atproto/oauth-client-node": "^0.3.17",
 		"@floating-ui/dom": "^1.7.6",
 		"@neondatabase/serverless": "^1.1.0",

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -3,7 +3,7 @@ import { getAccount } from '$lib/server/db/queries';
 import type { Handle } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ event, resolve }) => {
-	const session = await getSession(event.cookies);
+	const session = await getSession(event.cookies, event.url.origin);
 	const account = session ? await getAccount(session.did) : null;
 
 	if (session && account) {

--- a/apps/web/src/lib/server/atproto/records.ts
+++ b/apps/web/src/lib/server/atproto/records.ts
@@ -30,14 +30,18 @@ type WithStringUris<T> = T extends AtUriString
 
 export type PublishInput = WithStringUris<Omit<SketchRecord, '$type' | 'createdAt'>>;
 
-async function getLexClient(sessionDid: string): Promise<Client> {
-	const oauthClient = await getOAuthClient();
+async function getLexClient(sessionDid: string, origin?: string): Promise<Client> {
+	const oauthClient = await getOAuthClient(origin);
 	const session = await oauthClient.restore(sessionDid);
 	return new Client(session);
 }
 
-export async function publishSketch(sessionDid: string, input: PublishInput): Promise<StrongRef> {
-	const client = await getLexClient(sessionDid);
+export async function publishSketch(
+	sessionDid: string,
+	input: PublishInput,
+	origin?: string
+): Promise<StrongRef> {
+	const client = await getLexClient(sessionDid, origin);
 	const rkey = TID.nextStr();
 	return client.create(
 		sketchMain,
@@ -52,8 +56,12 @@ export async function publishSketch(sessionDid: string, input: PublishInput): Pr
 	);
 }
 
-export async function likeSketch(sessionDid: string, subject: StrongRef): Promise<StrongRef> {
-	const client = await getLexClient(sessionDid);
+export async function likeSketch(
+	sessionDid: string,
+	subject: StrongRef,
+	origin?: string
+): Promise<StrongRef> {
+	const client = await getLexClient(sessionDid, origin);
 	const rkey = TID.nextStr();
 	return client.create(
 		likeMain,
@@ -65,8 +73,12 @@ export async function likeSketch(sessionDid: string, subject: StrongRef): Promis
 	);
 }
 
-export async function repostSketch(sessionDid: string, subject: StrongRef): Promise<StrongRef> {
-	const client = await getLexClient(sessionDid);
+export async function repostSketch(
+	sessionDid: string,
+	subject: StrongRef,
+	origin?: string
+): Promise<StrongRef> {
+	const client = await getLexClient(sessionDid, origin);
 	const rkey = TID.nextStr();
 	return client.create(
 		repostMain,
@@ -78,8 +90,12 @@ export async function repostSketch(sessionDid: string, subject: StrongRef): Prom
 	);
 }
 
-export async function followUser(sessionDid: string, subjectDid: string): Promise<StrongRef> {
-	const client = await getLexClient(sessionDid);
+export async function followUser(
+	sessionDid: string,
+	subjectDid: string,
+	origin?: string
+): Promise<StrongRef> {
+	const client = await getLexClient(sessionDid, origin);
 	const rkey = TID.nextStr();
 	return client.create(
 		followMain,
@@ -88,12 +104,20 @@ export async function followUser(sessionDid: string, subjectDid: string): Promis
 	);
 }
 
-export async function unfollowUser(sessionDid: string, followUri: string): Promise<void> {
-	return deleteRecord(sessionDid, followUri);
+export async function unfollowUser(
+	sessionDid: string,
+	followUri: string,
+	origin?: string
+): Promise<void> {
+	return deleteRecord(sessionDid, followUri, origin);
 }
 
-export async function bookmarkSketch(sessionDid: string, subject: StrongRef): Promise<StrongRef> {
-	const client = await getLexClient(sessionDid);
+export async function bookmarkSketch(
+	sessionDid: string,
+	subject: StrongRef,
+	origin?: string
+): Promise<StrongRef> {
+	const client = await getLexClient(sessionDid, origin);
 	const rkey = TID.nextStr();
 	return client.create(
 		bookmarkMain,
@@ -106,12 +130,16 @@ export async function bookmarkSketch(sessionDid: string, subject: StrongRef): Pr
 	);
 }
 
-export async function unbookmarkSketch(sessionDid: string, bookmarkUri: string): Promise<void> {
-	return deleteRecord(sessionDid, bookmarkUri);
+export async function unbookmarkSketch(
+	sessionDid: string,
+	bookmarkUri: string,
+	origin?: string
+): Promise<void> {
+	return deleteRecord(sessionDid, bookmarkUri, origin);
 }
 
-export async function deleteRecord(sessionDid: string, uri: string): Promise<void> {
-	const client = await getLexClient(sessionDid);
+export async function deleteRecord(sessionDid: string, uri: string, origin?: string): Promise<void> {
+	const client = await getLexClient(sessionDid, origin);
 	// Parse AT URI: at://did/collection/rkey
 	const parts = uri.replace('at://', '').split('/');
 	await client.deleteRecord(parts[1] as NsidString, parts[2]);

--- a/apps/web/src/lib/server/atproto/records.ts
+++ b/apps/web/src/lib/server/atproto/records.ts
@@ -138,7 +138,11 @@ export async function unbookmarkSketch(
 	return deleteRecord(sessionDid, bookmarkUri, origin);
 }
 
-export async function deleteRecord(sessionDid: string, uri: string, origin?: string): Promise<void> {
+export async function deleteRecord(
+	sessionDid: string,
+	uri: string,
+	origin?: string
+): Promise<void> {
 	const client = await getLexClient(sessionDid, origin);
 	// Parse AT URI: at://did/collection/rkey
 	const parts = uri.replace('at://', '').split('/');

--- a/apps/web/src/lib/server/auth/client.ts
+++ b/apps/web/src/lib/server/auth/client.ts
@@ -1,3 +1,4 @@
+import { requestLocalLock } from '@atproto/oauth-client';
 import { NodeOAuthClient, buildAtprotoLoopbackClientMetadata } from '@atproto/oauth-client-node';
 import type { NodeSavedSession, NodeSavedState } from '@atproto/oauth-client-node';
 import { eq } from 'drizzle-orm';
@@ -69,7 +70,8 @@ export async function getOAuthClient(origin?: string): Promise<NodeOAuthClient> 
 				dpop_bound_access_tokens: true
 			},
 			stateStore,
-			sessionStore
+			sessionStore,
+			requestLock: requestLocalLock
 		});
 	} else {
 		client = new NodeOAuthClient({
@@ -78,7 +80,8 @@ export async function getOAuthClient(origin?: string): Promise<NodeOAuthClient> 
 				redirect_uris: [`${publicUrl ?? 'http://127.0.0.1:3000'}/oauth/callback`]
 			}),
 			stateStore,
-			sessionStore
+			sessionStore,
+			requestLock: requestLocalLock
 		});
 	}
 

--- a/apps/web/src/lib/server/auth/session.ts
+++ b/apps/web/src/lib/server/auth/session.ts
@@ -1,12 +1,12 @@
 import type { Cookies } from '@sveltejs/kit';
 import { getOAuthClient } from './client';
 
-export async function getSession(cookies: Cookies) {
+export async function getSession(cookies: Cookies, origin?: string) {
 	const did = getDid(cookies);
 	if (!did) return null;
 
 	try {
-		const client = await getOAuthClient();
+		const client = await getOAuthClient(origin);
 		return await client.restore(did);
 	} catch (e) {
 		console.error('Failed to restore OAuth session:', e);

--- a/apps/web/src/routes/api/bookmark/+server.ts
+++ b/apps/web/src/routes/api/bookmark/+server.ts
@@ -5,13 +5,17 @@ import { db } from '$lib/server/db';
 import { bookmarks } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
 
-export const POST: RequestHandler = async ({ request, locals }) => {
+export const POST: RequestHandler = async ({ request, locals, url }) => {
 	if (!locals.session.did) error(401, 'Not logged in');
 
 	const { subjectUri, subjectCid } = await request.json();
 	if (!subjectUri || !subjectCid) error(400, 'Missing subjectUri or subjectCid');
 
-	const ref = await bookmarkSketch(locals.session.did, { uri: subjectUri, cid: subjectCid });
+	const ref = await bookmarkSketch(
+		locals.session.did,
+		{ uri: subjectUri, cid: subjectCid },
+		url.origin
+	);
 
 	await db.insert(bookmarks).values({
 		uri: ref.uri,
@@ -24,13 +28,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	return json({ uri: ref.uri });
 };
 
-export const DELETE: RequestHandler = async ({ request, locals }) => {
+export const DELETE: RequestHandler = async ({ request, locals, url }) => {
 	if (!locals.session.did) error(401, 'Not logged in');
 
 	const { bookmarkUri } = await request.json();
 	if (!bookmarkUri) error(400, 'Missing bookmarkUri');
 
-	await unbookmarkSketch(locals.session.did, bookmarkUri);
+	await unbookmarkSketch(locals.session.did, bookmarkUri, url.origin);
 	await db.delete(bookmarks).where(eq(bookmarks.uri, bookmarkUri));
 	return new Response(null, { status: 204 });
 };

--- a/apps/web/src/routes/oauth/logout/+server.ts
+++ b/apps/web/src/routes/oauth/logout/+server.ts
@@ -2,12 +2,12 @@ import { json } from '@sveltejs/kit';
 import { getOAuthClient } from '$lib/server/auth/client';
 import type { RequestHandler } from './$types';
 
-export const POST: RequestHandler = async ({ cookies }) => {
+export const POST: RequestHandler = async ({ cookies, url }) => {
 	const did = cookies.get('did');
 
 	try {
 		if (did) {
-			const client = await getOAuthClient();
+			const client = await getOAuthClient(url.origin);
 			await client.revoke(did);
 		}
 	} catch (e) {

--- a/apps/web/src/routes/profile/[identifier]/+page.server.ts
+++ b/apps/web/src/routes/profile/[identifier]/+page.server.ts
@@ -45,7 +45,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 };
 
 export const actions: Actions = {
-	follow: async ({ params, locals }) => {
+	follow: async ({ params, locals, url }) => {
 		if (!locals.session.did) return fail(401, { error: 'Not logged in' });
 
 		let did: string;
@@ -56,7 +56,7 @@ export const actions: Actions = {
 		}
 
 		try {
-			const result = await followUser(locals.session.did, did);
+			const result = await followUser(locals.session.did, did, url.origin);
 			return { followUri: result.uri };
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Failed to follow';
@@ -64,7 +64,7 @@ export const actions: Actions = {
 		}
 	},
 
-	unfollow: async ({ request, locals }) => {
+	unfollow: async ({ request, locals, url }) => {
 		if (!locals.session.did) return fail(401, { error: 'Not logged in' });
 
 		const data = await request.formData();
@@ -72,7 +72,7 @@ export const actions: Actions = {
 		if (typeof followUri !== 'string') return fail(400, { error: 'Missing followUri' });
 
 		try {
-			await unfollowUser(locals.session.did, followUri);
+			await unfollowUser(locals.session.did, followUri, url.origin);
 			return {};
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Failed to unfollow';

--- a/apps/web/src/routes/repl/+page.server.ts
+++ b/apps/web/src/routes/repl/+page.server.ts
@@ -18,7 +18,7 @@ export const load: PageServerLoad = async ({ url }) => {
 };
 
 export const actions: Actions = {
-	publish: async ({ request, locals }) => {
+	publish: async ({ request, locals, url }) => {
 		if (!locals.session.did) {
 			return fail(401, { error: 'You must be logged in to publish.' });
 		}
@@ -48,14 +48,18 @@ export const actions: Actions = {
 				: undefined;
 
 		try {
-			const result = await publishSketch(locals.session.did, {
-				title: title.trim(),
-				code,
-				description: (typeof description === 'string' && description.trim()) || undefined,
-				tags,
-				previousVersion: (typeof prevVersion === 'string' && prevVersion.trim()) || undefined,
-				rootVersion: (typeof rootVersion === 'string' && rootVersion.trim()) || undefined
-			});
+			const result = await publishSketch(
+				locals.session.did,
+				{
+					title: title.trim(),
+					code,
+					description: (typeof description === 'string' && description.trim()) || undefined,
+					tags,
+					previousVersion: (typeof prevVersion === 'string' && prevVersion.trim()) || undefined,
+					rootVersion: (typeof rootVersion === 'string' && rootVersion.trim()) || undefined
+				},
+				url.origin
+			);
 
 			await db
 				.insert(sketches)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -26,7 +26,12 @@ interface CreateCodeMirrorOptions {
   onStop?: () => void;
 }
 
-const startState = ({ doc, onChange, onRun, onStop }: CreateCodeMirrorOptions) =>
+const startState = ({
+  doc,
+  onChange,
+  onRun,
+  onStop,
+}: CreateCodeMirrorOptions) =>
   EditorState.create({
     doc: doc ?? DEFAULT_DOC,
     extensions: [

--- a/packages/fluid/src/instruments/sampler.ts
+++ b/packages/fluid/src/instruments/sampler.ts
@@ -1,11 +1,7 @@
 import SampleNotes from "@/patterns/sample-notes";
 import Parameter from "@/patterns/parameter";
 import type { CycleInput } from "@/types";
-import type {
-  ClipMode,
-  FitSchema,
-  SamplerSchema,
-} from "@web-audio/schema";
+import type { ClipMode, FitSchema, SamplerSchema } from "@web-audio/schema";
 import { DEFAULT_BANK } from "@/banks";
 import Instrument from "./instrument";
 import type Drome from "@/index";

--- a/plans/atproto-auth/atproto-auth-db-lock-plan.md
+++ b/plans/atproto-auth/atproto-auth-db-lock-plan.md
@@ -1,0 +1,323 @@
+# AT Protocol Auth DB-backed Lock Implementation Plan
+
+## Context
+
+This plan implements the DB-backed OAuth lock described in `atproto-auth-db-lock-prd.md`.
+
+**Key design decisions:**
+
+- Implement after AT Protocol auth extraction unless production urgency requires otherwise.
+- The lock lives inside the extracted auth module.
+- The lock implements the AT Protocol OAuth client's `RuntimeLock` interface.
+- Use a table-based lock with owner tokens and TTL recovery.
+- Do not change the public auth facade API.
+- Do not change route handlers or app-domain record helpers.
+
+---
+
+## Phase 1: Schema and Migration
+
+### Step 1.1 — Add `authLock` schema
+
+**File:** `apps/web/src/lib/server/db/schema.ts`
+
+Add:
+
+```ts
+export const authLock = pgTable('auth_lock', {
+  name: text('name').primaryKey(),
+  owner: text('owner').notNull(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow()
+});
+```
+
+**Acceptance criteria:**
+
+- [ ] Schema exports `authLock`
+- [ ] Existing auth tables are unchanged
+- [ ] TypeScript compiles
+
+---
+
+### Step 1.2 — Generate migration
+
+Run:
+
+```sh
+pnpm --filter web db:generate
+```
+
+Review the generated migration.
+
+**Acceptance criteria:**
+
+- [ ] Migration creates `auth_lock`
+- [ ] `name` is the primary key
+- [ ] `owner` is non-null
+- [ ] `expires_at` is non-null
+- [ ] Migration does not modify unrelated tables
+
+---
+
+## Phase 2: Lock Helper
+
+### Step 2.1 — Create lock module
+
+**File:** `apps/web/src/lib/server/atproto-auth/lock.ts`
+
+Create constants:
+
+```ts
+const LOCK_TTL_MS = 30_000;
+const MAX_WAIT_MS = 10_000;
+const MIN_RETRY_DELAY_MS = 25;
+const MAX_RETRY_DELAY_MS = 100;
+```
+
+Create helpers:
+
+```ts
+function createOwnerId()
+function sleep(ms: number)
+function retryDelay()
+```
+
+**Acceptance criteria:**
+
+- [ ] Module exists in extracted auth module
+- [ ] No route imports this module directly
+- [ ] Owner IDs are unique enough for concurrent requests
+
+---
+
+### Step 2.2 — Implement atomic acquisition
+
+**File:** `apps/web/src/lib/server/atproto-auth/lock.ts`
+
+Implement an internal function:
+
+```ts
+async function tryAcquireLock(name: string, owner: string, expiresAt: Date): Promise<boolean>
+```
+
+Behavior:
+
+1. Try to insert `{ name, owner, expiresAt }`.
+2. If insert succeeds, return `true`.
+3. If conflict occurs, update the row only when existing `expiresAt < now()`.
+4. Return `true` only if insert/update affected a row.
+5. Otherwise return `false`.
+
+**Acceptance criteria:**
+
+- [ ] Only one contender can acquire an unexpired lock
+- [ ] Expired locks can be taken over
+- [ ] Acquisition updates owner and expiration together
+- [ ] No unsafe read-then-write race
+
+---
+
+### Step 2.3 — Implement owner-safe release
+
+**File:** `apps/web/src/lib/server/atproto-auth/lock.ts`
+
+Implement:
+
+```ts
+async function releaseLock(name: string, owner: string): Promise<void>
+```
+
+Delete only when both `name` and `owner` match.
+
+**Acceptance criteria:**
+
+- [ ] A request cannot delete a lock it no longer owns
+- [ ] Release is safe after timeout/takeover
+- [ ] Release failure does not mask the result of `fn()` unless it is truly fatal
+
+---
+
+### Step 2.4 — Implement `requestDbLock`
+
+**File:** `apps/web/src/lib/server/atproto-auth/lock.ts`
+
+Implement:
+
+```ts
+export async function requestDbLock<T>(name: string, fn: () => Promise<T> | T): Promise<T>
+```
+
+Behavior:
+
+1. Generate owner ID.
+2. Retry acquisition until success or `MAX_WAIT_MS` elapses.
+3. On success, execute `fn()`.
+4. Release lock in `finally`.
+5. Throw a clear timeout error if lock cannot be acquired.
+
+**Acceptance criteria:**
+
+- [ ] Implements `RuntimeLock` shape
+- [ ] Runs `fn()` exactly once after acquisition
+- [ ] Always attempts release after acquisition
+- [ ] Timeout error includes the lock name
+- [ ] Retry loop includes jitter
+
+---
+
+## Phase 3: OAuth Client Integration
+
+### Step 3.1 — Replace local lock
+
+**File:** `apps/web/src/lib/server/atproto-auth/client.ts`
+
+Replace:
+
+```ts
+import { requestLocalLock } from '@atproto/oauth-client';
+```
+
+with:
+
+```ts
+import { requestDbLock } from './lock';
+```
+
+Replace:
+
+```ts
+requestLock: requestLocalLock
+```
+
+with:
+
+```ts
+requestLock: requestDbLock
+```
+
+in both OAuth client constructors.
+
+**Acceptance criteria:**
+
+- [ ] OAuth client uses DB-backed lock
+- [ ] `requestLocalLock` import is removed
+- [ ] Client construction behavior is otherwise unchanged
+
+---
+
+### Step 3.2 — Reconsider dependency
+
+If `@atproto/oauth-client` is only used for `requestLocalLock`, remove the direct dependency from `apps/web/package.json` with an uninstall command.
+
+```sh
+pnpm --filter web remove @atproto/oauth-client
+```
+
+Only do this if no imports remain.
+
+**Acceptance criteria:**
+
+- [ ] No unused dependency remains
+- [ ] Lockfile is updated via pnpm
+
+---
+
+## Phase 4: Verification
+
+### Step 4.1 — Static checks
+
+Run:
+
+```sh
+pnpm check
+```
+
+**Acceptance criteria:**
+
+- [ ] TypeScript/Svelte checks pass
+- [ ] No lint/type errors from Drizzle expressions
+
+---
+
+### Step 4.2 — Migration verification
+
+Apply migration to the intended database environment before deploy.
+
+Depending on workflow, run the appropriate command, for example:
+
+```sh
+pnpm --filter web db:migrate
+```
+
+or use the deployment migration process.
+
+**Acceptance criteria:**
+
+- [ ] `auth_lock` exists in target database
+- [ ] App can start against migrated DB
+
+---
+
+### Step 4.3 — Manual concurrency verification
+
+Create or use a logged-in account with an OAuth session near/after access-token expiry.
+
+Trigger multiple authenticated requests concurrently, such as page load plus API requests, or a small script that calls an authenticated endpoint several times in parallel.
+
+**Acceptance criteria:**
+
+- [ ] Only one request holds a given lock at a time
+- [ ] Other requests wait rather than refreshing concurrently
+- [ ] No refresh-token rotation/revocation errors appear
+- [ ] Lock row is removed after completion
+
+---
+
+### Step 4.4 — Expired lock verification
+
+Manually insert or leave an expired lock row:
+
+```txt
+name = some test lock name
+owner = stale-owner
+expires_at = timestamp in the past
+```
+
+Then run a lock acquisition for the same name.
+
+**Acceptance criteria:**
+
+- [ ] Expired lock is taken over
+- [ ] Owner changes to the new owner
+- [ ] Lock releases cleanly afterward
+
+---
+
+## Phase 5: Cleanup and Documentation
+
+### Step 5.1 — Update notes/comments
+
+Document in the lock module:
+
+- why this lock exists
+- why owner-safe release is necessary
+- why TTL exists
+- why timeout fails closed
+
+**Acceptance criteria:**
+
+- [ ] Future readers understand the OAuth refresh-token race
+- [ ] Constants are easy to tune
+
+---
+
+### Step 5.2 — Remove obsolete temporary notes
+
+If any comments or docs still describe `requestLocalLock` as the active production lock, update them.
+
+**Acceptance criteria:**
+
+- [ ] Documentation reflects DB-backed lock as active implementation
+- [ ] No stale references to the temporary lock remain except in historical context

--- a/plans/atproto-auth/atproto-auth-db-lock-prd.md
+++ b/plans/atproto-auth/atproto-auth-db-lock-prd.md
@@ -1,0 +1,152 @@
+# AT Protocol Auth DB-backed Lock PRD
+
+## Overview
+
+Replace the temporary `requestLocalLock` OAuth refresh lock with a database-backed lock that works across processes, serverless invocations, and horizontally scaled app instances.
+
+The lock should implement the AT Protocol OAuth client's `RuntimeLock` interface and become an internal detail of the extracted AT Protocol auth module.
+
+## Goals
+
+- Prevent concurrent OAuth token refresh races across all app instances
+- Avoid refresh-token rotation conflicts that can revoke or invalidate credentials
+- Work in serverless and multi-instance production environments
+- Use the same database infrastructure as the existing OAuth session/state stores
+- Recover safely from crashed processes through lock expiration
+- Keep lock behavior invisible to routes and app-domain modules
+- Replace `requestLocalLock` without changing the auth facade API
+
+## Non-goals
+
+- Do not change the OAuth login/callback flow
+- Do not change cookie behavior
+- Do not change the saved OAuth session format
+- Do not introduce Redis or another new infrastructure dependency
+- Do not implement this before auth extraction unless production urgency requires it
+- Do not use an in-memory lock for production correctness
+
+---
+
+## Background
+
+The AT Protocol OAuth client can refresh credentials during session restore. Refresh tokens are sensitive to concurrent use because refresh-token rotation may invalidate the old refresh token after the first successful refresh.
+
+Without a cross-request lock, this race can happen:
+
+1. Two requests restore the same session at the same time.
+2. Both see an expired access token.
+3. Request A refreshes successfully and stores a new refresh token.
+4. Request B attempts to refresh with the old token.
+5. The OAuth server rejects or revokes credentials.
+
+`requestLocalLock` prevents this only within a single Node.js process. It does not protect separate serverless invocations or multiple deployed instances.
+
+---
+
+## Required Interface
+
+The OAuth client expects a `RuntimeLock`:
+
+```ts
+type RuntimeLock = <T>(name: string, fn: () => Awaitable<T>) => Awaitable<T>;
+```
+
+The DB-backed implementation should provide:
+
+```ts
+requestDbLock<T>(name: string, fn: () => Promise<T> | T): Promise<T>
+```
+
+The OAuth client remains configured the same way:
+
+```ts
+requestLock: requestDbLock
+```
+
+---
+
+## Proposed Storage
+
+Add a database table for auth locks:
+
+```ts
+export const authLock = pgTable('auth_lock', {
+  name: text('name').primaryKey(),
+  owner: text('owner').notNull(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow()
+});
+```
+
+## Lock Semantics
+
+A lock is identified by `name`, supplied by the OAuth client.
+
+Each acquisition attempt generates a unique `owner` token.
+
+Acquisition should:
+
+1. Insert the lock row if it does not exist.
+2. If it exists but is expired, atomically take it over with the new owner and new expiration.
+3. If it exists and is not expired, wait and retry.
+4. Fail with a clear timeout error if not acquired within the max wait period.
+
+Release should:
+
+1. Run in a `finally` block.
+2. Delete the row only if both `name` and `owner` match.
+3. Never delete another request's lock after expiration/takeover.
+
+## TTL and Retry Policy
+
+Initial defaults:
+
+- lock TTL: 30 seconds
+- retry delay: 25-100ms with jitter
+- max wait: 5-10 seconds
+
+If the lock cannot be acquired before timeout, OAuth work should fail rather than risk concurrent refresh-token rotation.
+
+---
+
+## Sequencing
+
+Implement this after `atproto-auth-extraction-prd.md` / `atproto-auth-extraction-plan.md`.
+
+The extraction centralizes auth client construction, so the DB-backed lock can be introduced by replacing one internal implementation detail:
+
+```ts
+requestLock: requestLocalLock
+```
+
+with:
+
+```ts
+requestLock: requestDbLock
+```
+
+Only reverse this order if production needs cross-process/serverless lock safety immediately.
+
+---
+
+## Acceptance Criteria
+
+- `auth_lock` table exists via Drizzle schema and migration
+- `requestDbLock` implements the OAuth `RuntimeLock` contract
+- Lock acquisition is atomic
+- Expired locks can be safely taken over
+- Lock release is owner-safe
+- Timed-out acquisition throws a clear error
+- OAuth client uses `requestDbLock` instead of `requestLocalLock`
+- Routes and app-domain modules do not change
+- `pnpm check` passes
+- Migration is applied before deployment
+
+---
+
+## Operational Notes
+
+- Lock rows should normally be short-lived and absent after successful requests.
+- Expired rows may remain after crashes and should be recoverable by takeover.
+- Table-based locks are preferred here over Postgres advisory locks because they are easy to inspect, work with serverless DB access patterns, and support TTL-based recovery.

--- a/plans/atproto-auth/atproto-auth-extraction-plan.md
+++ b/plans/atproto-auth/atproto-auth-extraction-plan.md
@@ -1,0 +1,364 @@
+# AT Protocol Auth Extraction Implementation Plan
+
+## Context
+
+This plan implements the internal AT Protocol auth facade described in `atproto-auth-extraction-prd.md`.
+
+**Key design decisions:**
+
+- Start as an internal `apps/web` server module.
+- Keep current OAuth behavior intact.
+- Keep `requestLocalLock` for now.
+- Preserve the recent origin fix: restore/revoke/client operations must use the current request origin in dev.
+- Do this before the DB-backed lock plan unless production urgently needs cross-process lock safety first.
+- Keep app-specific record operations outside the auth module.
+
+---
+
+## Phase 1: Module Scaffold
+
+### Step 1.1 — Create module directory
+
+**Files:**
+
+```txt
+apps/web/src/lib/server/atproto-auth/
+  index.ts
+  config.ts
+  client.ts
+  stores.ts
+  cookies.ts
+  session.ts
+  profile.ts
+```
+
+Create empty module files and decide which functions are public from `index.ts`.
+
+**Acceptance criteria:**
+
+- [ ] Directory exists
+- [ ] `index.ts` exports the intended facade functions
+- [ ] No behavior has changed yet
+
+---
+
+### Step 1.2 — Move constants/config
+
+**From:** `apps/web/src/lib/server/auth/client.ts`  
+**To:** `apps/web/src/lib/server/atproto-auth/config.ts`
+
+Move:
+
+- `SCOPE`
+- `PRODUCTION_CLIENT_ID`
+- cookie options if added during extraction
+
+**Acceptance criteria:**
+
+- [ ] OAuth scope remains unchanged
+- [ ] Production client ID remains unchanged
+- [ ] Existing imports compile
+
+---
+
+## Phase 2: Move OAuth Client Infrastructure
+
+### Step 2.1 — Move state/session stores
+
+**From:** `apps/web/src/lib/server/auth/client.ts`  
+**To:** `apps/web/src/lib/server/atproto-auth/stores.ts`
+
+Move the Drizzle-backed stores for:
+
+- `authState`
+- `authSession`
+
+**Acceptance criteria:**
+
+- [ ] Store behavior is unchanged
+- [ ] Existing OAuth sessions remain readable
+- [ ] No table or migration changes are introduced
+
+---
+
+### Step 2.2 — Move OAuth client construction
+
+**From:** `apps/web/src/lib/server/auth/client.ts`  
+**To:** `apps/web/src/lib/server/atproto-auth/client.ts`
+
+Move `getOAuthClient(origin?: string)` and client cache behavior.
+
+Keep:
+
+```ts
+requestLock: requestLocalLock
+```
+
+Keep production URL behavior:
+
+```ts
+const publicUrl = !dev && env.APP_URL ? env.APP_URL : origin;
+```
+
+**Acceptance criteria:**
+
+- [ ] Dev loopback metadata still uses request origin
+- [ ] Production still prefers `APP_URL`
+- [ ] Clients are still cached by public URL/cache key
+- [ ] `requestLocalLock` remains configured
+- [ ] No `Token was not issued to this client` regression in dev-port scenarios
+
+---
+
+## Phase 3: Cookies and Session Facade
+
+### Step 3.1 — Add cookie helpers
+
+**File:** `apps/web/src/lib/server/atproto-auth/cookies.ts`
+
+Centralize:
+
+- read DID cookie
+- set DID cookie
+- delete DID cookie
+- cookie name
+- cookie options
+
+Current cookie behavior to preserve:
+
+```ts
+cookies.set('did', session.did, {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax',
+  maxAge: 60 * 60 * 24 * 7,
+  path: '/'
+});
+```
+
+**Acceptance criteria:**
+
+- [ ] Cookie name remains `did`
+- [ ] Cookie options remain equivalent
+- [ ] Stale sessions delete the cookie at path `/`
+
+---
+
+### Step 3.2 — Move session restore
+
+**From:** `apps/web/src/lib/server/auth/session.ts`  
+**To:** `apps/web/src/lib/server/atproto-auth/session.ts`
+
+Implement:
+
+```ts
+getSession(event)
+```
+
+It should:
+
+1. Read DID from cookie.
+2. Return `null` if absent.
+3. Restore with `getOAuthClient(event.url.origin)`.
+4. Delete the DID cookie and return `null` on restore failure.
+
+**Acceptance criteria:**
+
+- [ ] Restore uses `event.url.origin`
+- [ ] Missing cookie returns `null`
+- [ ] Restore failure deletes stale cookie
+- [ ] Error logging remains useful
+
+---
+
+### Step 3.3 — Add Lex client helper
+
+**File:** `apps/web/src/lib/server/atproto-auth/session.ts`
+
+Implement:
+
+```ts
+getLexClient(sessionDid: string, origin: string)
+```
+
+It should restore the OAuth session with the origin-specific client and return an authenticated `@atproto/lex` `Client`.
+
+**Acceptance criteria:**
+
+- [ ] Existing record helpers can use `getLexClient`
+- [ ] Restore uses the correct origin
+- [ ] No app-specific record creation logic is moved into auth module
+
+---
+
+## Phase 4: Login, Callback, Logout Facade
+
+### Step 4.1 — Add login URL helper
+
+**File:** `apps/web/src/lib/server/atproto-auth/session.ts`
+
+Implement:
+
+```ts
+getAuthorizationUrl(event, handle)
+```
+
+It should:
+
+1. Get OAuth client for `event.url.origin`.
+2. Call `authorize(handle, { scope: SCOPE })`.
+3. Return the URL string.
+
+**Acceptance criteria:**
+
+- [ ] Login route no longer constructs OAuth client directly
+- [ ] Scope remains unchanged
+- [ ] Returned URL matches existing behavior
+
+---
+
+### Step 4.2 — Move profile/account hydration
+
+**From:** `apps/web/src/routes/oauth/callback/+server.ts`  
+**To:** `apps/web/src/lib/server/atproto-auth/profile.ts`
+
+Move `fetchAndCacheProfile(did)` or equivalent.
+
+**Acceptance criteria:**
+
+- [ ] Callback still upserts account profile
+- [ ] Failed profile fetch does not fail login
+- [ ] App-specific DB write remains isolated to `profile.ts`
+
+---
+
+### Step 4.3 — Add callback handler
+
+**File:** `apps/web/src/lib/server/atproto-auth/session.ts`
+
+Implement:
+
+```ts
+handleCallback(event)
+```
+
+It should:
+
+1. Get OAuth client for `event.url.origin`.
+2. Call `client.callback(event.url.searchParams)`.
+3. Set DID cookie.
+4. Fetch/cache profile.
+5. Return the session or DID if useful.
+
+**Acceptance criteria:**
+
+- [ ] Callback route becomes thin
+- [ ] DID cookie is set correctly
+- [ ] Profile/account cache still updates
+- [ ] Errors still route to login failure behavior
+
+---
+
+### Step 4.4 — Add logout helper
+
+**File:** `apps/web/src/lib/server/atproto-auth/session.ts`
+
+Implement:
+
+```ts
+logout(event)
+```
+
+It should:
+
+1. Read DID cookie.
+2. If present, revoke with `getOAuthClient(event.url.origin)`.
+3. Always delete the DID cookie in `finally`.
+
+**Acceptance criteria:**
+
+- [ ] Logout route no longer constructs OAuth client directly
+- [ ] Revoke uses request origin
+- [ ] Cookie is deleted even if revoke fails
+
+---
+
+## Phase 5: Update Call Sites
+
+### Step 5.1 — Update hooks
+
+**File:** `apps/web/src/hooks.server.ts`
+
+Use facade `getSession(event)`.
+
+**Acceptance criteria:**
+
+- [ ] Locals shape remains unchanged
+- [ ] Account lookup behavior remains unchanged unless intentionally folded into facade
+
+---
+
+### Step 5.2 — Update OAuth routes
+
+**Files:**
+
+- `apps/web/src/routes/oauth/login/+server.ts`
+- `apps/web/src/routes/oauth/callback/+server.ts`
+- `apps/web/src/routes/oauth/logout/+server.ts`
+
+Replace direct auth plumbing with facade calls.
+
+**Acceptance criteria:**
+
+- [ ] Routes are thinner
+- [ ] Response status/redirect behavior remains unchanged
+
+---
+
+### Step 5.3 — Update record helpers
+
+**File:** `apps/web/src/lib/server/atproto/records.ts`
+
+Use `getLexClient(sessionDid, origin)` from the auth module.
+
+**Acceptance criteria:**
+
+- [ ] Publish/bookmark/follow/unfollow still work
+- [ ] Origin is still threaded from request handlers
+
+---
+
+### Step 5.4 — Remove old auth module or leave compatibility shim
+
+**Files:**
+
+- `apps/web/src/lib/server/auth/client.ts`
+- `apps/web/src/lib/server/auth/session.ts`
+
+Prefer removing these if no imports remain. If removal is too disruptive, leave temporary re-export shims.
+
+**Acceptance criteria:**
+
+- [ ] No stale direct OAuth helper imports remain outside the new module
+- [ ] `grep` confirms `getOAuthClient()` is only used internally by `atproto-auth`
+
+---
+
+## Phase 6: Verification
+
+Run:
+
+```sh
+pnpm check
+```
+
+Manual verification:
+
+- [ ] Login works
+- [ ] Callback redirects to `/`
+- [ ] Account profile appears after login
+- [ ] Session survives server restart
+- [ ] Dev port mismatch does not reappear
+- [ ] Logout works
+- [ ] Publish/bookmark/follow/unfollow work
+- [ ] OAuth lock warning remains gone

--- a/plans/atproto-auth/atproto-auth-extraction-prd.md
+++ b/plans/atproto-auth/atproto-auth-extraction-prd.md
@@ -1,0 +1,193 @@
+# AT Protocol Auth Extraction PRD
+
+## Overview
+
+Extract the web app's AT Protocol OAuth/auth plumbing behind a small server-side facade. The extraction should reduce route-level complexity, centralize auth behavior, and make future auth infrastructure changes, especially the DB-backed lock, easier to implement safely.
+
+This begins as an internal `apps/web` module, not a reusable workspace package. The module can be promoted later if the API stabilizes or another app needs the same auth flow.
+
+## Goals
+
+- Hide AT Protocol OAuth client construction from routes and app-domain modules
+- Centralize dev/prod client metadata behavior, including origin-sensitive loopback clients in dev
+- Centralize OAuth state/session stores
+- Centralize DID cookie handling
+- Centralize session restore, stale-session cleanup, callback handling, logout, and revoke
+- Provide one place to configure token refresh locking
+- Expose a small interface for authenticated AT Protocol client access
+- Preserve current behavior and recent fixes for dev-port/client-origin mismatches
+- Keep app-specific record operations separate from auth mechanics
+
+## Non-goals
+
+- Do not create a standalone package in the first pass
+- Do not redesign the OAuth flow
+- Do not change login UX
+- Do not change database schema as part of the extraction
+- Do not implement the DB-backed lock in this feature; that is covered by `atproto-auth-db-lock-prd.md` and `atproto-auth-db-lock-plan.md`
+- Do not hide app-domain record behavior such as publishing sketches, bookmarks, follows, or custom lexicon record creation
+
+---
+
+## Current Problem
+
+Auth complexity is currently spread across:
+
+- `apps/web/src/lib/server/auth/client.ts`
+- `apps/web/src/lib/server/auth/session.ts`
+- `apps/web/src/hooks.server.ts`
+- `apps/web/src/routes/oauth/login/+server.ts`
+- `apps/web/src/routes/oauth/callback/+server.ts`
+- `apps/web/src/routes/oauth/logout/+server.ts`
+- `apps/web/src/lib/server/atproto/records.ts`
+
+As a result, routes and domain modules need to know too much about:
+
+- `NodeOAuthClient`
+- loopback metadata
+- production client metadata
+- origin-specific dev clients
+- session restore details
+- token refresh locks
+- cookie names/options
+- profile caching after login
+- constructing authenticated AT Protocol `Client` instances
+
+This makes auth behavior harder to reason about and increases the chance of regressions like restoring a dev session with the wrong OAuth client origin.
+
+---
+
+## Proposed Abstraction
+
+Create an internal module:
+
+```txt
+apps/web/src/lib/server/atproto-auth/
+```
+
+The rest of the app should interact with this module through a small facade.
+
+## Public API
+
+Initial function-based API:
+
+```ts
+getSession(event)
+getAuthorizationUrl(event, handle)
+handleCallback(event)
+logout(event)
+getLexClient(sessionDid, origin)
+```
+
+Expected usage:
+
+```ts
+const session = await atprotoAuth.getSession(event);
+const redirectUrl = await atprotoAuth.getAuthorizationUrl(event, handle);
+await atprotoAuth.handleCallback(event);
+await atprotoAuth.logout(event);
+const client = await atprotoAuth.getLexClient(sessionDid, event.url.origin);
+```
+
+## Responsibilities
+
+The auth module owns:
+
+- OAuth scope
+- production client ID
+- client metadata construction
+- per-origin client caching
+- state/session stores
+- DID cookie read/write/delete
+- callback processing
+- session restore
+- session revoke/logout
+- `requestLock` configuration
+- authenticated Lex client construction
+- profile/account hydration hook after successful login
+
+The app/domain layer owns:
+
+- `event.locals.session` shape
+- database account model
+- custom record creation/deletion
+- Drome lexicon-specific operations
+- route redirects/responses
+
+---
+
+## Target Route Shape
+
+### Hook
+
+```ts
+const session = await atprotoAuth.getSession(event);
+
+event.locals.session = session
+  ? session
+  : { did: null, handle: null, displayName: null, avatar: null };
+```
+
+### Login
+
+```ts
+const redirectUrl = await atprotoAuth.getAuthorizationUrl(event, handle);
+return json({ redirectUrl });
+```
+
+### Callback
+
+```ts
+await atprotoAuth.handleCallback(event);
+redirect(302, '/');
+```
+
+### Logout
+
+```ts
+await atprotoAuth.logout(event);
+return json({ success: true });
+```
+
+### Record writes
+
+```ts
+const client = await atprotoAuth.getLexClient(sessionDid, origin);
+```
+
+---
+
+## Sequencing
+
+This extraction should happen before the DB-backed lock feature.
+
+`requestLocalLock` is already in place as a temporary single-process fix. Extracting auth first lets the later DB-backed lock become an internal implementation detail of the auth module instead of adding more lock-related code to the currently scattered structure and moving it afterward.
+
+Only reverse this order if production deployment urgently requires cross-process/serverless refresh-token safety before extraction can happen.
+
+---
+
+## Acceptance Criteria
+
+- Routes no longer import `NodeOAuthClient` helpers directly
+- OAuth login still redirects correctly
+- OAuth callback still sets the DID cookie
+- Callback still fetches/caches the user's profile/account
+- Session restore still works after server restart
+- Dev-port/client-origin mismatch does not regress
+- Logout still revokes using the correct origin-specific client
+- Record writes can still obtain an authenticated AT Protocol `Client`
+- `requestLocalLock` remains configured
+- `pnpm check` passes
+
+---
+
+## Future Package Extraction
+
+Consider promoting this to `packages/atproto-auth` only after:
+
+- another app needs the same auth flow
+- the facade API stabilizes
+- the DB-backed lock is implemented and stable
+- storage/profile behavior is adapter-based
+- tests exist around cookie, store, lock, and restore behavior

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       '@atproto/lex':
         specifier: ^0.0.25
         version: 0.0.25
+      '@atproto/oauth-client':
+        specifier: 0.6.1
+        version: 0.6.1
       '@atproto/oauth-client-node':
         specifier: ^0.3.17
         version: 0.3.17


### PR DESCRIPTION
## Summary
- thread request origin through ATProto OAuth session restore/revoke and record write helpers
- add requestLocalLock to silence the OAuth lock warning and prevent same-process refresh races
- add PRDs/plans for ATProto auth extraction and a future DB-backed lock

## Validation
- pnpm check